### PR TITLE
Add CI for Scala Backend with GitHub Actions

### DIFF
--- a/.github/workflows/scala-ci.yaml
+++ b/.github/workflows/scala-ci.yaml
@@ -1,0 +1,34 @@
+name: Scala Backend CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'sbt'
+
+    - name: Build with SBT
+      run: sbt compile
+      
+    - name: Run tests
+      run: sbt test


### PR DESCRIPTION
기본적인 Scala backend CI를 위한 GitHub Actions yaml을 작성하였습니다.

1. main, develop 브랜치에 pr 또는 push가 발생하면
2. sbt compile & sbt test를 수행합니다.

GitHub Actions를 사용하기 위해 main 브랜치에 .github/workflows 폴더가 필요해서, develop 브랜치에 merge 후 main 브랜치로 merge 하려 합니다. merge 방식으로는 [GitHub의 Merge, Squash and Merge, Rebase and Merge 정확히 이해하기](https://meetup.nhncloud.com/posts/122) 글에 따라 develop 브랜치로는 Squash and Merge, Main 브랜치로는 Rebase and Merge를 고려하고 있는데 이 부분도 의견 부탁드립니다.